### PR TITLE
fix: purge ALL hardcoded/mock data — BFF single source of truth

### DIFF
--- a/src/data/AgentStore.ts
+++ b/src/data/AgentStore.ts
@@ -2,25 +2,28 @@ import { create } from "zustand";
 import type { AgentState, AgentStatus } from "./types";
 
 // ---------------------------------------------------------------------------
-// Initial agent positions — overwritten by real BFF data on connect
+// Initial agent layout — positions only. All other data comes from BFF.
+// Names/roles here are fallback if BFF hasn't connected yet.
 // ---------------------------------------------------------------------------
-const MOCK_AGENTS: AgentState[] = [
-  { id: "pm", name: "Артём", role: "PM", status: "working", currentTask: "Координация спринта", lastMessage: "Коля, PR #77 готов к ревью", lastActiveAt: new Date().toISOString(), tileX: 3, tileY: 2, direction: "se", avatar: null },
-  { id: "dev", name: "Коля", role: "Developer", status: "working", currentTask: "Phase 1 scaffold", lastMessage: "Принял, делаю", lastActiveAt: new Date().toISOString(), tileX: 5, tileY: 3, direction: "sw", avatar: null },
-  { id: "analyst", name: "Лена", role: "Analyst", status: "thinking", currentTask: "Сценарии приёмки", lastMessage: null, lastActiveAt: new Date().toISOString(), tileX: 2, tileY: 4, direction: "se", avatar: null },
-  { id: "devops", name: "Дима", role: "DevOps", status: "idle", currentTask: null, lastMessage: "Деплой готов", lastActiveAt: new Date().toISOString(), tileX: 6, tileY: 2, direction: "nw", avatar: null },
-  { id: "qa", name: "Саша", role: "QA", status: "working", currentTask: "Тестирование #77", lastMessage: "3 бага найдено", lastActiveAt: new Date().toISOString(), tileX: 4, tileY: 5, direction: "se", avatar: null },
-  { id: "techlead", name: "Макс", role: "Tech Lead", status: "thinking", currentTask: "Ревью архитектуры", lastMessage: null, lastActiveAt: new Date().toISOString(), tileX: 4, tileY: 1, direction: "sw", avatar: null },
+const INITIAL_AGENTS: AgentState[] = [
+  { id: "pm", name: "PM", role: "PM", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 3, tileY: 2, direction: "se", avatar: null },
+  { id: "dev", name: "Dev", role: "Developer", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 5, tileY: 3, direction: "sw", avatar: null },
+  { id: "analyst", name: "Analyst", role: "Analyst", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 2, tileY: 4, direction: "se", avatar: null },
+  { id: "devops", name: "DevOps", role: "DevOps", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 6, tileY: 2, direction: "nw", avatar: null },
+  { id: "qa", name: "QA", role: "QA", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 4, tileY: 5, direction: "se", avatar: null },
+  { id: "techlead", name: "Tech Lead", role: "Tech Lead", status: "idle", currentTask: null, lastMessage: null, lastActiveAt: null, tileX: 4, tileY: 1, direction: "sw", avatar: null },
 ];
 
 interface AgentStoreState {
   agents: AgentState[];
   updateAgent: (id: string, update: Partial<AgentState>) => void;
   setStatus: (id: string, status: AgentStatus) => void;
+  /** Replace all agents with data from BFF */
+  setAgents: (agents: AgentState[]) => void;
 }
 
 export const useAgentStore = create<AgentStoreState>((set) => ({
-  agents: MOCK_AGENTS,
+  agents: INITIAL_AGENTS,
 
   updateAgent: (id, update) =>
     set((state) => ({
@@ -31,4 +34,6 @@ export const useAgentStore = create<AgentStoreState>((set) => ({
     set((state) => ({
       agents: state.agents.map((a) => (a.id === id ? { ...a, status } : a)),
     })),
+
+  setAgents: (agents) => set({ agents }),
 }));

--- a/src/data/ws-client.ts
+++ b/src/data/ws-client.ts
@@ -62,21 +62,9 @@ function connect() {
     try {
       const msg: BFFMessage = JSON.parse(event.data as string);
       if (msg.type === "agents" && Array.isArray(msg.data)) {
-        const store = useAgentStore.getState();
-        for (const agent of msg.data) {
-          // Sync all fields from BFF — real OpenClaw data overrides mock
-          store.updateAgent(agent.id, {
-            status: agent.status,
-            currentTask: agent.currentTask,
-            lastMessage: agent.lastMessage,
-            lastActiveAt: agent.lastActiveAt,
-            // Sync positions from BFF (they reflect office zone layout)
-            tileX: agent.tileX,
-            tileY: agent.tileY,
-            direction: agent.direction,
-          });
-        }
-        console.log(`[WS] Synced ${msg.data.length} agents (real data)`);
+        // Full replace — BFF is the single source of truth
+        useAgentStore.getState().setAgents(msg.data);
+        console.log(`[WS] Synced ${msg.data.length} agents (real OpenClaw data)`);
       }
     } catch (err) {
       console.warn("[WS] Failed to parse message:", err);


### PR DESCRIPTION
Purged:
- Fake agent names/tasks/messages from AgentStore
- Partial update logic (was keeping stale mock fields)

Now: agents start as generic placeholders, BFF does FULL replace on every sync. Zero hardcoded data visible to user.