### PR TITLE
fix: nginx WS proxy — WebSocket from external IP

### DIFF
--- a/infrastructure/nginx/default.conf
+++ b/infrastructure/nginx/default.conf
@@ -31,6 +31,25 @@ server {
         try_files $uri =404;
     }
 
+    # BFF WebSocket proxy — /db/ws → bff:3101
+    location /db/ws {
+        proxy_pass http://bff:3101;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
+    # BFF API proxy — /db/api/* → bff:3101/*
+    location /db/api/ {
+        proxy_pass http://bff:3101/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Fixes ws://localhost:3101 failed error. Nginx now proxies /db/ws → BFF WebSocket and /db/api → BFF HTTP.