### PR TITLE
fix: #46 #48 — merge conflict markers + double height in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="theme-color" content="#0f0e17" />
+    <meta name="theme-color" content="#f5f5f7" />
     <title>OpenClaw Dashboard</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
-<<<<<<< HEAD
-      html, body, #root { width: 100%; height: 100dvh; height: 100%; overflow: hidden; }
+      html, body, #root { width: 100%; height: 100vh; height: 100dvh; overflow: hidden; }
       body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; }
-=======
-      html, body, #root { width: 100%; height: 100%; overflow: hidden; }
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f7; color: #1d1d1f; }
->>>>>>> origin/main
     </style>
   </head>
   <body>


### PR DESCRIPTION
## CRITICAL: дашборд крашится при загрузке

### #46 Merge conflict маркеры
Строки `<<<<<<< HEAD`, `=======`, `>>>>>>> origin/main` в index.html вызывали crash браузера.

### #48 Двойной height
Решение: `100vh` (fallback) + `100dvh` (override для мобильных).

### Также
- theme-color: `#f5f5f7` (светлая тема)

Билд чистый, 0 conflict маркеров в dist.