### PR TITLE
fix: slide-in panel + mobile stats + activity events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,7 @@ export function App() {
 
       {/* Overlay UI */}
       <ConnectionBadge />
-      {!isMobile && <Metrics />}
+      <Metrics />
       {!isMobile && <Timeline />}
       {!isMobile && <Heatmap />}
       <TaskButton />

--- a/src/data/ws-client.ts
+++ b/src/data/ws-client.ts
@@ -3,7 +3,22 @@
  * Includes exponential backoff reconnect to prevent OOM from rapid retries.
  */
 import { useAgentStore } from "./AgentStore";
+import { useActivityStore } from "./ActivityStore";
 import type { AgentState } from "./types";
+
+/** Track previous statuses to detect changes → generate activity events */
+const prevStatuses = new Map<string, string>();
+
+const STATUS_EVENT_MAP: Record<string, { type: "message" | "task_started" | "task_completed" | "deploy" | "review"; text: string }> = {
+  working: { type: "task_started", text: "начал работу" },
+  talking: { type: "message", text: "общается" },
+  thinking: { type: "message", text: "думает над задачей" },
+  deploying: { type: "deploy", text: "деплоит" },
+  reviewing: { type: "review", text: "ревьюит код" },
+  testing: { type: "task_started", text: "тестирует" },
+  sleeping: { type: "message", text: "ушёл спать" },
+  celebrating: { type: "task_completed", text: "празднует завершение" },
+};
 
 function getWsUrl(): string {
   if (import.meta.env.VITE_BFF_WS_URL) return import.meta.env.VITE_BFF_WS_URL;
@@ -92,6 +107,17 @@ function connect() {
               direction: agent.direction,
             });
           }
+        }
+
+        // Generate activity events from status changes
+        const actStore = useActivityStore.getState();
+        for (const agent of msg.data) {
+          const prev = prevStatuses.get(agent.id);
+          if (prev && prev !== agent.status && agent.status !== "idle") {
+            const ev = STATUS_EVENT_MAP[agent.status];
+            if (ev) actStore.addEvent(agent.id, ev.type as any, ev.text);
+          }
+          prevStatuses.set(agent.id, agent.status);
         }
       }
     } catch (err) {

--- a/src/engine/Scene.tsx
+++ b/src/engine/Scene.tsx
@@ -347,10 +347,13 @@ export function Scene({ agents, onAgentClick, selectedZone, onZoneClick, sceneRe
     const offsetX = W / 2 + panRef.current.x;
     const offsetY = H / 2 - 50 + panRef.current.y;
 
+    // Hit test agents — match render position (sprite drawn at sy - SPRITE_SIZE - 4)
     const currentAgents = agentsRef.current;
     for (const agent of currentAgents) {
       const { x, y } = tileToScreen(agent.tileX, agent.tileY);
-      if (Math.abs(mx - (x + offsetX)) < 32 && Math.abs(my - (y + offsetY - SPRITE_SIZE / 2)) < 36) {
+      const agentCenterX = x + offsetX;
+      const agentCenterY = y + offsetY - SPRITE_SIZE / 2 - 4; // match render offset
+      if (Math.abs(mx - agentCenterX) < 36 && Math.abs(my - agentCenterY) < 40) {
         onAgentClickRef.current(agent.id);
         return;
       }

--- a/src/ui/Metrics.tsx
+++ b/src/ui/Metrics.tsx
@@ -44,22 +44,25 @@ function MetricCard({ emoji, label, value, total, color }: {
 
 const containerStyle: React.CSSProperties = {
   position: "absolute",
-  top: 70,
-  left: 20,
+  top: 60,
+  left: 12,
   display: "flex",
-  flexDirection: "column",
-  gap: "6px",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: "4px",
+  maxWidth: "calc(100vw - 24px)",
 };
 
 const cardStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  gap: "2px",
-  background: "rgba(15, 14, 23, 0.85)",
-  border: "1px solid #2a2a4a",
-  borderRadius: "10px",
-  padding: "8px 12px",
-  minWidth: "60px",
+  gap: "1px",
+  background: "rgba(255, 255, 255, 0.85)",
+  border: "1px solid #e5e5ea",
+  borderRadius: "8px",
+  padding: "4px 8px",
+  minWidth: "44px",
   backdropFilter: "blur(10px)",
+  fontSize: "10px",
 };


### PR DESCRIPTION
## 3 бага после QA (16/20 тестов)

### 1. Slide-in панель не открывается
**Причина:** hitTest Y offset не совпадал с render position.
Render: `sy - SPRITE_SIZE - 4`, hitTest: `sy - SPRITE_SIZE/2`
**Fix:** hitTest offset = `SPRITE_SIZE/2 + 4`, hitbox 36×40px

### 2. Мобильная: заголовок и статистика скрыты
**Причина:** `{!isMobile && <Metrics />}`
**Fix:** Metrics всегда видны, горизонтальный layout с flexWrap, компактные карточки

### 3. Activity Feed 0 events
**Причина:** BFF отправляет agent states, не events
**Fix:** Фронтенд детектит изменения статусов → генерирует activity events
(working→task_started, talking→message, deploying→deploy и т.д.)

Build: 75KB ✅