### PR TITLE
fix(nginx): add /db/<path> → bff:3101 location (closes #90)

### DIFF
--- a/infrastructure/nginx/default.conf
+++ b/infrastructure/nginx/default.conf
@@ -50,6 +50,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    # BFF REST shortcut — /db/<path> → bff:3101/<path>
+    # Handles game.html BFF_BASE="/db" requests (e.g. /db/tasks, /db/events, /db/metrics)
+    # Must be listed AFTER /db/api/ and /db/ws to avoid capturing those routes.
+    location ~ ^/db/(?!api/|ws)(.*) {
+        proxy_pass http://172.17.0.1:3101/$1$is_args$args;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Problem
`game.html` has `BFF_BASE = '/db'`, so REST requests go to:
- `POST /db/tasks` → nginx → **404** (no matching location)
- `GET /db/tasks` → nginx → **404**

Existing nginx had `/db/api/` → bff but not bare `/db/<path>`.

## Fix
Added regex location **after** `/db/api/` and `/db/ws` (so those keep priority):

```nginx
location ~ ^/db/(?!api/|ws)(.*) {
    proxy_pass http://127.0.0.1:3101/$1$is_args$args;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
}
```

This routes `/db/tasks`, `/db/events`, `/db/metrics` → bff:3101
while `/db/api/*` and `/db/ws` keep their existing rules.

## Files changed
- `infrastructure/nginx/default.conf` — added location block

## Host deploy required
Run on the server:
```bash
sudo cp infrastructure/nginx/default.conf /etc/nginx/sites-available/agro
# (or apply the diff manually)
sudo nginx -t && sudo systemctl reload nginx
```

Closes #90